### PR TITLE
Fix memory leak in proxy speed middleware

### DIFF
--- a/lib/middleware/speed.js
+++ b/lib/middleware/speed.js
@@ -11,13 +11,13 @@ var changeResponsesSpeed = module.exports = function () {
 
     var res = this.res;
     var req = this.req;
-    var timer = 1;
-    var size = Math.ceil(this.speed / 8);
+    var timer = 125;
+    var size = Math.ceil(this.speed * 16);
     var prms = Promise.resolve();
-    
+
     var resWrite = res.write;
     var resEnd = res.end;
-    
+
     var promisify = args => {
 
         var chunk = args[0];
@@ -37,10 +37,12 @@ var changeResponsesSpeed = module.exports = function () {
     };
 
     res.write = function () {
+        if (size === 0) return; // reject responses if speed is zero
         promisify(Array.from(arguments));
     };
 
     res.end = function () {
+        if (size === 0) return; // reject responses if speed is zero
         var args = Array.from(arguments);
         promisify(args);
 


### PR DESCRIPTION
Due to small time period of response, it leaded to high memory
usage on small speed.
Now response period time is 1 sec and has special processing for
zero speed.